### PR TITLE
Cleanup 1024x1024 icons for Octave.

### DIFF
--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -325,9 +325,11 @@ modules:
   - --with-blas=openblas
   - --with-java-homedir=/app/jre
   - --with-java-includedir=/usr/lib/sdk/openjdk11/jvm/openjdk-11/include
+  cleanup:
+  - /share/icons/hicolor/1024x1024 # workaround for https://savannah.gnu.org/bugs/?55836
   sources:
   - type: archive
     url: https://ftp.gnu.org/gnu/octave/octave-5.1.0.tar.xz
     sha256: 87b4df6dfa28b1f8028f69659f7a1cabd50adfb81e1e02212ff22c863a29454e
   - type: patch
-    path: octave-add-content-rating.patch
+    path: octave-add-content-rating.patch # can be removed with the next stable Octave release


### PR DESCRIPTION
Add cleanup property for the octave module to remove 1024x1024 icons.  This is a limitation of Flatpak discussed at:
- https://savannah.gnu.org/bugs/?55836
- https://github.com/flatpak/flatpak/pull/2696