### PR TITLE
Update openblas to 0.3.6

### DIFF
--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -70,8 +70,8 @@ modules:
   - PREFIX=/app
   sources:
   - type: archive
-    url: https://github.com/xianyi/OpenBLAS/archive/v0.3.5.tar.gz
-    sha256: 0950c14bd77c90a6427e26210d6dab422271bc86f9fc69126725833ecdaa0e85
+    url: https://github.com/xianyi/OpenBLAS/archive/v0.3.6.tar.gz
+    sha256: e64c8fe083832ffbc1459ab6c72f71d53afd3b36e8497c922a15a06b72e9002f
 
 - shared-modules/glu/glu-9.0.0.json
 


### PR DESCRIPTION
As described in #73, we cannot make use of version 0.3.7 and have to wait for 0.3.8 for the fix xianyi/OpenBLAS#2215 to be merged.