### PR TITLE
include OCTAVE_HOME in the environment

### DIFF
--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -20,6 +20,7 @@ finish-args:
 - --env=PATH=/app/bin:/usr/bin:/app/jre/bin
 - --env=CPPFLAGS=-I/app/include # required for building some Octave forge packages
 - --env=LDFLAGS=-L/app/lib # required for building some Octave forge packages
+- --env=OCTAVE_HOME=/app
 cleanup:
 - /bin/*lpr*.sh
 - /bin/GraphicsMagick*config


### PR DESCRIPTION
Ensure that the confined Octave installation directory is found, even if
the caller has OCTAVE_HOME set.