### PR TITLE
Testbuild for portaudio.

### DIFF
--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -210,6 +210,8 @@ modules:
       - type: archive
         url: http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz
         sha256: f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
+      - type: patch
+        path: portaudio-test.patch
 
   - name: graphicsmagick
     config-opts:

--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -205,13 +205,12 @@ modules:
 
   - name: portaudio
     config-opts:
-      - --enable-debug-output
+      - --disable-static
+      - --without-oss
     sources:
       - type: archive
         url: http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz
         sha256: f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
-      - type: patch
-        path: portaudio-test.patch
 
   - name: graphicsmagick
     config-opts:

--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -204,6 +204,8 @@ modules:
         sha256: 4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10
 
   - name: portaudio
+    config-opts:
+      - --enable-debug-output
     sources:
       - type: archive
         url: http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz

--- a/portaudio-test.patch
+++ b/portaudio-test.patch
@@ -1,0 +1,12 @@
+diff -Naur portaudio/src/hostapi/alsa/pa_linux_alsa.c portaudio_/src/hostapi/alsa/pa_linux_alsa.c
+--- portaudio/src/hostapi/alsa/pa_linux_alsa.c	2016-10-30 10:23:04.000000000 +0900
++++ portaudio_/src/hostapi/alsa/pa_linux_alsa.c	2020-02-14 16:50:07.993742218 +0900
+@@ -1450,7 +1450,7 @@
+
+         PA_ENSURE( FillInDevInfo( alsaApi, hwInfo, blocking, devInfo, &devIdx ) );
+     }
+-    assert( devIdx < numDeviceNames );
++    //assert( devIdx < numDeviceNames );
+     /* Now inspect 'dmix' and 'default' plugins */
+     for( i = 0; i < numDeviceNames; ++i )
+     {


### PR DESCRIPTION
Configure portaudio with `--enable-debug-output`.  Attempt to fix #95 .