### PR TITLE
remove --filesystem=xdg-config/kdeglobals:ro

### DIFF
--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -14,7 +14,6 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --filesystem=host
-  - --filesystem=xdg-config/kdeglobals:ro # gives application access to kdeglobals
   - --talk-name=com.canonical.AppMenu.Registrar # gives application access to dbus menu
   - --talk-name=org.freedesktop.Flatpak # allows spawning processes on the host via flatpak-spawn --host
   - --env=PATH=/app/bin:/usr/bin:/app/jre/bin


### PR DESCRIPTION
Remove this redundant filesystem permission, no longer need to specify
since it is automatically inherited from the KDE runtime version 5.12
and later.