### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.octave.Octave.yaml
+++ b/org.octave.Octave.yaml
@@ -13,7 +13,12 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
-  - --filesystem=host
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/var/run/media
+  - --filesystem=/var/mnt
   - --talk-name=com.canonical.AppMenu.Registrar # required for global menu
   - --talk-name=org.freedesktop.Flatpak # allows spawning processes on the host via flatpak-spawn --host
   - --env=PATH=/app/bin:/usr/bin:/app/jre/bin


### PR DESCRIPTION
it should not have host access. Maybe remove some of the allowed directories

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt