### PR TITLE
OpenBLAS: Avoid leaking instruction set of build system

### DIFF
--- a/octave-modules.yaml
+++ b/octave-modules.yaml
@@ -30,6 +30,8 @@ modules:
         config-opts:
           - -DBUILD_SHARED_LIBS=ON
           - -DDYNAMIC_ARCH=ON
+          - -DDYNAMIC_OLDER=ON
+          - -DTARGET=GENERIC
           - -DUSE_OPENMP=ON
           - -DBUILD_WITHOUT_CBLAS=ON
           - -DNO_LAPACKE=1


### PR DESCRIPTION
If OpenBLAS is built with `DYNAMIC_ARCH`, it might select baseline kernels that require the instruction set of the platform on which the OpenBLAS library was built unless the baseline target is specified by `TARGET` (see OpenMathLib/OpenBLAS#5563).
Suppose that the OpenBLAS library that was built without `TARGET` on a build system with a processor that supports, e.g., the AVX-512 instruction set. If that library is then used on a processor without AVX-512 instructions, execution fails with a SIGILL (see https://savannah.gnu.org/bugs/?68225 where this was observed for Octave as distributed on Flathub).

Avoid that by selecting the `GENERIC` target for the baseline kernel for the `DYNAMIC_ARCH` build of OpenBLAS. That is also what Debian uses for the OpenBLAS packages with `DYNAMIC_ARCH` that they distribute: https://sources.debian.org/src/openblas/0.3.32%2Bds-5/debian/rules#L39

Additionally, enable building kernels for older processors similar to what Debian does.

Fixes #465.

@kasraghu: Does this look good to you?
